### PR TITLE
Save CI time by not using homebrew

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -3,10 +3,9 @@
 set -ex
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then
-    brew update || brew update
-    brew outdated pyenv || brew upgrade pyenv
-    brew install pyenv-virtualenv
-    brew install cmake || brew upgrade cmake || true
+    unset PYENV_ROOT
+    curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+    export PATH="$HOME/.pyenv/bin:$PATH"
 
     if which pyenv > /dev/null; then
         eval "$(pyenv init -)"
@@ -18,7 +17,7 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     pyenv activate conan
 fi
 
-pip install conan --upgrade
+pip install conan cmake --upgrade
 pip install conan_package_tools bincrafters_package_tools
 
 conan user

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -15,9 +15,11 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     pyenv virtualenv 3.7.1 conan
     pyenv rehash
     pyenv activate conan
+
+    pip install cmake --upgrade
 fi
 
-pip install conan cmake --upgrade
+pip install conan --upgrade
 pip install conan_package_tools bincrafters_package_tools
 
 conan user


### PR DESCRIPTION
| Name   | XCode  | Time with brew  | Time without brew  | Time reduction | Time reduction % |
|---|---|---|---|---|---|
| **enet**  |   | [CI job](https://travis-ci.com/bincrafters/conan-enet/builds/118314776)  | [CI job](https://travis-ci.com/bincrafters/conan-enet/builds/121987070)  |   |   |
|   |  ~~7.3~~  | ~~15m49s~~  |  ~~4m49s~~  | ~~11m0s~~  | ~~69,55%~~  |
|   | 8.3   | 11m56s  |  5m14s | 6m42s  | 56.15%  |
|   | 9   | 11m47s  | 5m16s  | 6m31s  | 55.3%  |
|   | 9.4  | 11m44s  |  5m38s  | 6m6s  | 51.19%  |
|   | 10.2   | 11m23s  | 6m23s  | 5m0s  | 43.92%   |
|   | ~~11 (beta 5)~~   | ~~7m5s~~  | ~~6m18s~~  | ~~0m57s~~   | ~~13.41%~~   |
|   |  |   | **Average time saving**  | 6m5s  |    |
|---|---|---|---|---|---|
| **QT**  |   | [CI job](https://travis-ci.com/bincrafters/conan-qt/builds/121779599)  | [CI job](https://travis-ci.com/bincrafters/conan-qt/builds/122004197)  |   |   |
|   | 10.01-page1  | 40m53s  |  35m5s  | 5m48s  | 14.19% |
|   | 10.01-page2   | 37m41s  |  32m4s | 5m37s  | 14.9%  |
|   | 10.01-page3   | 39m52s  | 30m47s  | 9m5s  | 22.78%  |
|   | 10.01-page4  | 34m41s  |  30m0s  | 4m41s  | 13.5% |
|   |  |   | **Average time saving**  | 6m18s  |    |
|---|---|---|---|---|---|


### Notes & Take-aways
  * Even though I have added data for XCode 7.3 it doesn't really matter as we don't add it anymore to new recipes and phasing it out from existing ones
  * Similar, XCode 11 beta doesn't matter right now as it is too new
  * The homebrew command which takes the longest is `update`, i.e. the older the homebrew cache is the longer takes the command the longer takes the entire CI job
    * as an result newer Travis macOS images which do have a newer homebrew cache (at least most of the time), the faster the jobs are **_-with-_** homebrew
    * since the XCode 11 beta image is brand new the time saving compared to my suggestion is only ~1 minute, as soon as the image gets older we would see the same time saving as with the other macOS images 
  * **_we save on average 6 minutes for every single macOS CI job_**
 * for small libraries like enet that can mean a time saving of ~50%

