### PR TITLE
Prebuilds: Drop several configurations

### DIFF
--- a/default/.travis.yml
+++ b/default/.travis.yml
@@ -1,3 +1,6 @@
+env:
+   global:
+     - CONAN_ARCHS=x86_64
 linux: &linux
    os: linux
    dist: xenial

--- a/default/appveyor.yml
+++ b/default/appveyor.yml
@@ -1,17 +1,15 @@
-build: false
-
 environment:
-    PYTHON_HOME: "C:\\Python37"
+  PYTHON_HOME: "C:\\Python37"
 
-    matrix:
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-          CONAN_VISUAL_VERSIONS: 12
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-          CONAN_VISUAL_VERSIONS: 14
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-          CONAN_VISUAL_VERSIONS: 15
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-          CONAN_VISUAL_VERSIONS: 16
+  CONAN_ARCHS: x86_64
+
+  matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      CONAN_VISUAL_VERSIONS: 14
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CONAN_VISUAL_VERSIONS: 15
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      CONAN_VISUAL_VERSIONS: 16
 
 install:
   - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%

--- a/header_only/appveyor.yml
+++ b/header_only/appveyor.yml
@@ -1,11 +1,9 @@
-build: false
-
 environment:
-    PYTHON_HOME: "C:\\Python37"
+  PYTHON_HOME: "C:\\Python37"
 
-    matrix:
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-          CONAN_VISUAL_VERSIONS: 15
+  matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CONAN_VISUAL_VERSIONS: 15
 
 install:
   - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%

--- a/installer_only/appveyor.yml
+++ b/installer_only/appveyor.yml
@@ -1,15 +1,13 @@
-build: false
-
 environment:
-    PYTHON_HOME: "C:\\Python37"
+  PYTHON_HOME: "C:\\Python37"
 
-    matrix:
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-          CONAN_VISUAL_VERSIONS: 15
-          ARCH: x86
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-          CONAN_VISUAL_VERSIONS: 15
-          ARCH: x86_64
+  matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CONAN_VISUAL_VERSIONS: 15
+      ARCH: x86
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CONAN_VISUAL_VERSIONS: 15
+      ARCH: x86_64
 
 install:
   - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%


### PR DESCRIPTION
In order to adopt to CCI:

  * Drop all 32-bit builds for libraries on Linux & Windows

  * Drop all Visual Studio 2013 builds

Also:

  * Fix weird indentation in AppVeyor YAML file & remove unnecessary build keyword


Fixes https://github.com/bincrafters/community/issues/954