### PR TITLE
More CCI adoptions

### DIFF
--- a/default/.travis.yml
+++ b/default/.travis.yml
@@ -35,9 +35,6 @@ matrix:
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/clang8
       - <<: *osx
-        osx_image: xcode9
-        env: CONAN_APPLE_CLANG_VERSIONS=9.0
-      - <<: *osx
         osx_image: xcode9.4
         env: CONAN_APPLE_CLANG_VERSIONS=9.1
       - <<: *osx

--- a/default/conanfile.py
+++ b/default/conanfile.py
@@ -8,9 +8,7 @@ class LibnameConan(ConanFile):
     topics = ("conan", "libname", "logging")
     url = "https://github.com/bincrafters/conan-libname"
     homepage = "https://github.com/original_author/original_lib"
-    author = "Bincrafters <bincrafters@gmail.com>"
     license = "MIT"  # Indicates license type of the packaged library; please use SPDX Identifiers https://spdx.org/licenses/
-    exports = ["LICENSE.md"]      # Packages the license for the conanfile.py
     # Remove following lines if the target lib does not use CMake
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake"

--- a/header_only/conanfile.py
+++ b/header_only/conanfile.py
@@ -8,12 +8,8 @@ class LibnameConan(ConanFile):
     topics = ("conan", "libname", "logging")
     url = "https://github.com/bincrafters/conan-libname"
     homepage = "https://github.com/original_author/original_lib"
-    author = "Bincrafters <bincrafters@gmail.com>"
     license = "MIT"  # Indicates license type of the packaged library; please use SPDX Identifiers https://spdx.org/licenses/
     no_copy_source = True
-
-    # Packages the license for the conanfile.py
-    exports = ["LICENSE.md"]
 
     _source_subfolder = "source_subfolder"
 

--- a/installer_only/conanfile.py
+++ b/installer_only/conanfile.py
@@ -8,10 +8,8 @@ class LibnameConan(ConanFile):
     topics = ("conan", "libname", "logging")
     url = "https://github.com/bincrafters/conan-libname"
     homepage = "https://github.com/original_author/original_lib"
-    author = "Bincrafters <bincrafters@gmail.com>"
     license = "MIT"  # Indicates license type of the packaged library; please use SPDX Identifiers https://spdx.org/licenses/
-    exports = ["LICENSE.md"]      # Packages the license for the conanfile.py
-    # Remove following lines if the target lib does not use cmake.
+    # Remove following lines if the target lib does not use CMake
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake"
 


### PR DESCRIPTION
  * remove Apple Clang 9.0 build jobs
  * remove `author` attribute, as recipes are getting maintained by a community and not a single person or entity
  * remove license exports as all CCI and Bincrafters recipes are MIT licensed and we would need to use a relative path for the license file in CCI or copy the same MIT license file in way too many sub-directories.... 

